### PR TITLE
Add Windows support

### DIFF
--- a/trunk/JoeQuake.vcxproj
+++ b/trunk/JoeQuake.vcxproj
@@ -389,6 +389,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="fmod.c" />
+    <ClCompile Include="ghost\demoparse.c" />
+    <ClCompile Include="ghost\ghost.c" />
+    <ClCompile Include="ghost\ghostparse.c" />
     <ClCompile Include="gl_decals.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Software Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Software Debug|Win32'">true</ExcludedFromBuild>
@@ -651,6 +654,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="fakegl.h" />
+    <ClInclude Include="ghost\demoparse.h" />
+    <ClInclude Include="ghost\ghost.h" />
+    <ClInclude Include="ghost\ghost_private.h" />
     <ClInclude Include="gl_model.h" />
     <ClInclude Include="glquake.h" />
     <ClInclude Include="cdaudio.h" />

--- a/trunk/JoeQuake.vcxproj.filters
+++ b/trunk/JoeQuake.vcxproj.filters
@@ -107,6 +107,12 @@
     <Filter Include="Source Files\Unzip">
       <UniqueIdentifier>{12143103-6799-4a01-9045-015d2da6e652}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Ghost">
+      <UniqueIdentifier>{512f4200-96b7-4b35-a2d9-71b0c6b0e8c1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Ghost_h">
+      <UniqueIdentifier>{93535a27-753e-43e4-983d-0bc3e222b987}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="joequake.rc">
@@ -411,6 +417,15 @@
     <ClCompile Include="unzip.c">
       <Filter>Source Files\Unzip</Filter>
     </ClCompile>
+    <ClCompile Include="ghost\demoparse.c">
+      <Filter>Source Files\Ghost</Filter>
+    </ClCompile>
+    <ClCompile Include="ghost\ghost.c">
+      <Filter>Source Files\Ghost</Filter>
+    </ClCompile>
+    <ClCompile Include="ghost\ghostparse.c">
+      <Filter>Source Files\Ghost</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="adivtab.h">
@@ -589,6 +604,15 @@
     </ClInclude>
     <ClInclude Include="gl_warp_sin.h">
       <Filter>Header Files\OpenGL_h</Filter>
+    </ClInclude>
+    <ClInclude Include="ghost\demoparse.h">
+      <Filter>Header Files\Ghost_h</Filter>
+    </ClInclude>
+    <ClInclude Include="ghost\ghost.h">
+      <Filter>Header Files\Ghost_h</Filter>
+    </ClInclude>
+    <ClInclude Include="ghost\ghost_private.h">
+      <Filter>Header Files\Ghost_h</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trunk/ghost/demoparse.c
+++ b/trunk/ghost/demoparse.c
@@ -476,10 +476,13 @@ DP_ParseUpdate(ctx_t *ctx, byte base_flags)
     unsigned int flags;
     int entity_num;
     int frame = -1;
-    vec3_t origin = {};
-    vec3_t angle = {};
+    vec3_t origin;
+    vec3_t angle;
     byte origin_bits = 0;
     byte angle_bits = 0;
+
+    VectorClear(origin);
+    VectorClear(angle);
 
     CHECK_RC(DP_ParseUpdateFlags(ctx, base_flags, &flags));
 

--- a/trunk/ghost/demoparse.c
+++ b/trunk/ghost/demoparse.c
@@ -434,7 +434,9 @@ DP_ParseBaseline(ctx_t *ctx, qboolean static_, int version)
         CHECK_RC(DP_ParseByte(ctx, NULL));  // alpha
     }
 
-    CALL_CALLBACK(baseline, entity_num, origin, angle, frame);
+    if (!static_) {
+        CALL_CALLBACK(baseline, entity_num, origin, angle, frame);
+    }
 
     return DP_ERR_SUCCESS;
 }


### PR DESCRIPTION
* Fix non-standard empty initializer braces that MSVC does not accept
* Fix use of uninitialized variable entity_num
* Add ghost files to build in Visual Studio project 